### PR TITLE
[PR] 키보드의 표시 상태를 저장하는 로직으로 리팩토링

### DIFF
--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -11,6 +11,7 @@ final class DiaryDetailViewController: UIViewController {
     $0.adjustsFontForContentSizeCategory = true
   }
 
+  private var isKeyboardShow = false
   private let diary: Diary
 
   init(diary: Diary) {
@@ -74,7 +75,12 @@ final class DiaryDetailViewController: UIViewController {
   }
 
   private func observeKeyboardNotifications() {
-    self.observeKeyboardWillShowNotification()
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(keyboardWillShow(_:)),
+      name: UIResponder.keyboardWillShowNotification,
+      object: nil
+    )
 
     NotificationCenter.default.addObserver(
       self,
@@ -84,34 +90,24 @@ final class DiaryDetailViewController: UIViewController {
     )
   }
 
-  private func observeKeyboardWillShowNotification() {
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(keyboardWillShow(_:)),
-      name: UIResponder.keyboardWillShowNotification,
-      object: nil
-    )
-  }
-
   @objc private func keyboardWillShow(_ notification: Notification) {
-    guard let userInfo = notification.userInfo else { return }
-    guard let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+    if !isKeyboardShow {
+      guard let userInfo = notification.userInfo else { return }
+      guard let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
 
-    let contentInset = UIEdgeInsets(bottom: keyboardFrame.height)
-    self.bodyTextView.contentInset = contentInset
-    self.bodyTextView.verticalScrollIndicatorInsets = contentInset
-
-    NotificationCenter.default.removeObserver(
-      self,
-      name: UIResponder.keyboardWillShowNotification,
-      object: nil
-    )
+      let contentInset = UIEdgeInsets(bottom: keyboardFrame.height)
+      self.bodyTextView.contentInset = contentInset
+      self.bodyTextView.verticalScrollIndicatorInsets = contentInset
+      self.isKeyboardShow = true
+    }
   }
 
   @objc private func keyboardWillHide(_ notification: Notification) {
-    let contentInset = UIEdgeInsets.zero
-    self.bodyTextView.contentInset = contentInset
-    self.bodyTextView.scrollIndicatorInsets = contentInset
-    self.observeKeyboardWillShowNotification()
+    if isKeyboardShow {
+      let contentInset = UIEdgeInsets.zero
+      self.bodyTextView.contentInset = contentInset
+      self.bodyTextView.scrollIndicatorInsets = contentInset
+      self.isKeyboardShow = false
+    }
   }
 }


### PR DESCRIPTION
## 배경
https://github.com/yagom-academy/ios-diary/pull/5#discussion_r901070803

> 음 저라면 키보드가 표시는지의 상태를 저장하거나 해서 필터링을 했을 것 같기는 합니다. 매번 제거하고 추가하는게 이상적인 구현은 아닐 것 같다는 생각이 드네요. 만약 작업하신 방식으로도 의도한 대로 동작이 잘 되신다면 이번에 꼭 수정할 필요는 없고 제 의견 참고해서 나중에 반영을 하거나 그냥 놔두셔도 될 듯 하네요.

## 작업 내용
- Notification을 지워주는 방식에서 keyboard의 표시 상태를 저장하여 필터링하는 방식으로 변경했습니다.

### 스크린샷 및 영상
![스크린샷 2022-06-21 오후 2 31 45](https://user-images.githubusercontent.com/94151993/174723289-d3e7f4d5-019e-48d1-bce7-005c704cc796.png)

